### PR TITLE
Fix cleanFilename (#606)

### DIFF
--- a/app/utils/utils.common.ts
+++ b/app/utils/utils.common.ts
@@ -14,10 +14,10 @@ export function omit<T extends object, U extends keyof T>(object: T, ...props: U
         .reduce((newObj, key) => Object.assign(newObj, { [key]: object[key] }), {} as any);
 }
 
-export function cleanFilename(str) {
+export function cleanFilename(str, wsRep=(w => '_')) {
     return str
         .replace(/[\x00-\x1f\x7f"*\/:<>?\\|\0x7f]+/g, encodeURIComponent)
-        .replace(/[\s\t\n]+/g, '_')
+        .replace(/\s/g, wsRep);
 }
 export function getFormatedDateForFilename(value?: number, dateFormat = ApplicationSettings.getString(SETTINGS_FILE_NAME_FORMAT, FILENAME_DATE_FORMAT), clean = true) {
     const now = dayjs(value);

--- a/app/utils/utils.common.ts
+++ b/app/utils/utils.common.ts
@@ -15,7 +15,9 @@ export function omit<T extends object, U extends keyof T>(object: T, ...props: U
 }
 
 export function cleanFilename(str) {
-    return str.replace(/[|?*<\":>+\[\]'"]+/g, '').replace(/[\\\s\t\n\/]+/g, '_');
+    return str
+        .replace(/[\x00-\x1f\x7f"*\/:<>?\\|\0x7f]+/g, encodeURIComponent)
+        .replace(/[\s\t\n]+/g, '_')
 }
 export function getFormatedDateForFilename(value?: number, dateFormat = ApplicationSettings.getString(SETTINGS_FILE_NAME_FORMAT, FILENAME_DATE_FORMAT), clean = true) {
     const now = dayjs(value);


### PR DESCRIPTION
As requested in #606, remove `'+` from the bad characters regex (also removed `[]` which are also legal, discovered in implementation).
Made whitespace handling configurable in `cleanFilename`, unsure where/how to add the configuration knob to select the behaviour.
The configuration should allow setting `wsRep` to:
- `w => '_'` (current behaviour)
- `w => encodeURIComponent` (to match other "bad" characters)
- `w => w` (do nothing -- whitespace is not problematic)
